### PR TITLE
gsplat: improve tasks

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -2,13 +2,13 @@ version: '3'
 
 dotenv: ['.env']
 
-env:
-  TORCH_CUDA_ARCH_LIST: "7.5+PTX"  # Defining the env here does not work for gsplat. It must be defined inside its Dockerfile.
-
 includes:
   gsplat: 
     taskfile: ./gsplat/Taskfile.yaml
     dir: ./gsplat
+    vars:
+      TORCH_CUDA_ARCH_LIST: "7.5+PTX"
+      MAX_JOBS: 10
   hierarchical-3d-gaussians: 
     taskfile: ./hierarchical-3d-gaussians/Taskfile.yaml
     dir: ./hierarchical-3d-gaussians

--- a/gsplat/README.md
+++ b/gsplat/README.md
@@ -50,11 +50,6 @@ python3 examples/simple_trainer.py default \
 --result_dir data/results/some-output-folder
 ```
 
-python examples/simple_trainer.py default \
---data_dir data/360_v2/garden \
---data_factor 8 \
---result_dir data/results/garden-test
-
 where:
 
 - `--data_dir` is the path to the dataset you'd like to use. Specify the folder containing `images` and `sparse`.

--- a/gsplat/Taskfile.yaml
+++ b/gsplat/Taskfile.yaml
@@ -5,7 +5,6 @@ vars:
   VERSION_TAG: 1.4.0
   REPOSITORIES: 
     - ghcr.io/fabulani
-    - harbor.management.twinverse.dev/twinverse
   TAGS:  # Tags are formed like so: REPO/NAME:VERSION_TAG, for REPO in REPOSITORIES
     sh: |
       for repo in {{ range $i, $repo := .REPOSITORIES }}{{ if $i }} {{ end }}"{{ $repo }}"{{ end }}; do

--- a/gsplat/Taskfile.yaml
+++ b/gsplat/Taskfile.yaml
@@ -5,9 +5,13 @@ vars:
   VERSION_TAG: 1.4.0
   REPOSITORIES: 
     - ghcr.io/fabulani
-  TAGS: 
-    - "{{ index .REPOSITORIES 0 }}/{{ .NAME }}:{{ .VERSION_TAG }}"  # TODO: is it possible to for loop .REPOSITORIES?
-  
+    - harbor.management.twinverse.dev/twinverse
+  TAGS:  # Tags are formed like so: REPO/NAME:VERSION_TAG, for REPO in REPOSITORIES
+    sh: |
+      for repo in {{ range $i, $repo := .REPOSITORIES }}{{ if $i }} {{ end }}"{{ $repo }}"{{ end }}; do
+        echo "$repo/{{ .NAME }}:{{ .VERSION_TAG }}"
+      done
+
 tasks:
   clone:
     desc: Clone gsplat

--- a/gsplat/Taskfile.yaml
+++ b/gsplat/Taskfile.yaml
@@ -1,18 +1,19 @@
 version: '3'
 
 vars:
-  TAG: ghcr.io/fabulani/nerfstudio-gsplat:1.4.0
-  REPO_PATH: ./repo
+  NAME: nerfstudio-gsplat
+  VERSION_TAG: 1.4.0
+  REPOSITORIES: 
+    - ghcr.io/fabulani
+  TAGS: 
+    - "{{ index .REPOSITORIES 0 }}/{{ .NAME }}:{{ .VERSION_TAG }}"  # TODO: is it possible to for loop .REPOSITORIES?
   
-env:
-  MAX_JOBS: 10
-  TORCH_CUDA_ARCH_LIST: "7.5+PTX"  # Defining the env here does not work. It must be defined inside the Dockerfile.
-
 tasks:
   clone:
     desc: Clone gsplat
     vars:
       REPO: https://github.com/nerfstudio-project/gsplat.git
+      REPO_PATH: ./repo
       COMMIT_ID: e86f392
     cmds: 
       - |
@@ -23,21 +24,29 @@ tasks:
 
   build:
     desc: Build gsplat image
-    cmd: |
+    requires:
+      vars: [TORCH_CUDA_ARCH_LIST, MAX_JOBS]
+    cmds: 
+      - |
         docker build \
-        --build-arg TORCH_CUDA_ARCH_LIST=$TORCH_CUDA_ARCH_LIST \
-        -t {{.TAG}} \
+        --build-arg TORCH_CUDA_ARCH_LIST={{.TORCH_CUDA_ARCH_LIST}} \
+        --build-arg MAX_JOBS={{.MAX_JOBS}} \
+        -t "{{ .NAME }}:{{ .VERSION_TAG }}" \
         -f ./docker/Dockerfile ./docker
+      - for: { var: TAGS }
+        cmd: docker tag "{{ .NAME }}:{{ .VERSION_TAG }}" "{{ .ITEM }}"
 
   push:
-    desc: Push gsplat image to Github Container Registry
+    desc: Push image to registry
     cmds:
-      - docker push {{.TAG}}
+      - for: { var: TAGS }
+        cmd: docker push {{ .ITEM }}
 
   pull:
-    desc: Pull gsplat image from Github Container Registry
+    desc: Pull image from registry
     cmds:
-      - docker pull {{.TAG}}
+      - docker pull {{ index .TAGS 0 }}
+      - docker tag {{ index .TAGS 0 }} "{{ .NAME }}:{{ .VERSION_TAG }}"
 
   run:
     desc: Run gsplat

--- a/gsplat/docker/Dockerfile
+++ b/gsplat/docker/Dockerfile
@@ -1,13 +1,15 @@
 # For CUDA 11.8, use: pytorch/pytorch:2.6.0-cuda11.8-cudnn9-devel
 FROM pytorch/pytorch:2.6.0-cuda12.6-cudnn9-devel
 
-# For some reason, TORCH_CUDA_ARCH_LIST must be defined in the Dockerfile, otherwise gsplat will not compile. 
-# Passing it as a build-arg does not work, neither does defining it as an env variable in the Taskfile.
-ENV TORCH_CUDA_ARCH_LIST="7.5+PTX"
+
+# Build arguments
+ARG TORCH_CUDA_ARCH_LIST="7.5+PTX"
+ENV TORCH_CUDA_ARCH_LIST=${TORCH_CUDA_ARCH_LIST}
+ARG MAX_JOBS=10
+ENV MAX_JOBS=${MAX_JOBS}
 
 WORKDIR /workspace
 
-# Required for install of packages from examples/requirements.txt.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     wget \

--- a/gsplat/docker/docker-compose.yml
+++ b/gsplat/docker/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     container_name: nerfstudio-gsplat
     stdin_open: true
     tty: true 
-    image: ghcr.io/fabulani/nerfstudio-gsplat:1.4.0
+    image: nerfstudio-gsplat:1.4.0
     pull_policy: never
     volumes:  # Change to named volumes for production!
       - ${DATA_PATH}:/workspace/gsplat/data


### PR DESCRIPTION
gsplat tasks now allow multiple repositories, and fixes the `--build-arg` issue with `TORCH_CUDA_ARCH_LIST`.